### PR TITLE
added set_paper call to the wrapper, otherwise the paper size will alway...

### DIFF
--- a/Wrapper/DompdfWrapper.php
+++ b/Wrapper/DompdfWrapper.php
@@ -32,6 +32,7 @@ class DompdfWrapper
 
 		$this->pdf = new \DOMPDF();
 
+		$this->pdf->set_paper(DOMPDF_DEFAULT_PAPER_SIZE);
 		$this->pdf->load_html($html);
 		$this->pdf->render();
 	}


### PR DESCRIPTION
...s be "letter" (default in dompdf)
