### PR TITLE
Make bundle resolveable by composer with SF3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": ">=5.3",
-        "symfony/framework-bundle": "2.*",
-        "symfony/symfony": "2.*"
+        "symfony/framework-bundle": "2.*|~3.0",
+        "symfony/symfony": "2.*|~3.0"
     },
     "autoload":     {
         "psr-0": { "Slik\\DompdfBundle": "" }


### PR DESCRIPTION
This is the only thing stopping me upgrading to Symfony3.

For anyone wanting to live life on the edge, here are my changes to `composer.json` to manually get @wcoppens changes:

```
{

   // Your config etc.

    "repositories": [
        {
            "type": "git",
            "url": "https://github.com/wcoppens/DompdfBundle.git"
        }
    ],

    "require": {

        // Other includes...

        "slik/dompdf-bundle": "dev-sf-3"
    },

    // Other stuff

}
```
