### PR TITLE
Add paper size and orientation options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /vendor
 /nbproject
 /Resources/doc/generated
+.idea
 
 *.tmp
 *.patch

--- a/DomPDF/dompdf_config.custom.inc.php
+++ b/DomPDF/dompdf_config.custom.inc.php
@@ -5,6 +5,7 @@
 //define("DOMPDF_PDF_BACKEND", "PDFLib");
 //define("DOMPDF_DEFAULT_MEDIA_TYPE", "print");
 define("DOMPDF_DEFAULT_PAPER_SIZE", "a4");
+define("DOMPDF_DEFAULT_ORIENTATION", "portrait");
 define("DOMPDF_DEFAULT_FONT", "helvetica");
 define("DOMPDF_DPI", 150);
 //define("DOMPDF_ENABLE_PHP", true);

--- a/Wrapper/DompdfWrapper.php
+++ b/Wrapper/DompdfWrapper.php
@@ -16,10 +16,11 @@ class DompdfWrapper
 
 	/**
 	 * Render a pdf document
-	 * @param  string $html    The html to be rendered
-	 * @param  string $docname The name of the document to be served
-	 */
-	public function getpdf($html)
+     * @param string $html        The html to be rendered
+     * @param string $papersize   The size of the page to render, defaults to DOMPDF_DEFAULT_PAPER_SIZE
+     * @param string $orientation The orientation of the page to render, defaults to DOMPDF_DEFAULT_ORIENTATION
+     */
+	public function getpdf($html, $papersize = null, $orientation = null)
 	{
 		// test if dompdf config exists in symfony app folder
 		$testFilePath = "/../../../../../../app/dompdf_config.inc.php";
@@ -30,9 +31,13 @@ class DompdfWrapper
 			require_once dirname(__FILE__).'/../DomPDF/dompdf_config.inc.php';
 		}
 
+        // Have to use contants here because they are undefined until required above
+        $papersize = is_null($papersize) ? DOMPDF_DEFAULT_PAPER_SIZE : $papersize;
+        $orientation = is_null($orientation) ? DOMPDF_DEFAULT_ORIENTATION : $orientation;
+
 		$this->pdf = new \DOMPDF();
 
-		$this->pdf->set_paper(DOMPDF_DEFAULT_PAPER_SIZE);
+		$this->pdf->set_paper($papersize, $orientation);
 		$this->pdf->load_html($html);
 		$this->pdf->render();
 	}


### PR DESCRIPTION
Without being able to specify the paper size and orientation yourself, you're stuck with the default portrait a4. This gives the option of specifying it yourself but also falling back to default values if you're happy with them.
